### PR TITLE
chore: update LICENSE copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2014 Tom Harwood
 Copyright (c) 2025 I9si Sistemas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This PR updates the copyright year in the LICENSE file from 2025 to 2014 and adds Tom Harwood as a copyright holder. This ensures the license accurately reflects the project's copyright status.